### PR TITLE
Better progress reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ fn report_progress(done: usize, total: usize) -> String {
     write!(&mut buf, "{}", "・".repeat(scaled_done)).unwrap();
     write!(&mut buf, "C").unwrap();
     write!(&mut buf, "{}", "o ".repeat(SCALER - scaled_done)).unwrap();
-    write!(&mut buf, "] {:3}%", (done as f32) / (total as f32) * 100.0).unwrap();
+    write!(&mut buf, "] {:3.0}%", (done as f32) / (total as f32) * 100.0).unwrap();
 
     buf
 }


### PR DESCRIPTION
Was noticing some clunky logging in the console when trying to test bulk submission (for load testing). This adds a progress report that makes it easier to read.  
```
Submitting reports: [・・・・・・・・・Co o o o o ] 75%
```