### PR TITLE
Add a script to run submission and collection jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,19 @@ DAP_ENV=prod cargo run
 
 `DAP_ENV` can be any of `prod`, `stage`, and `dev` with `dev` is used as the default if this environment variable is not specified.
 
+## Run via Docker
 
+A docker image is provided to run the submission job with `dap-random-client` and then the collection job with `janus-collect`. By default, it will submit reports to the `dev` environment (for the Aggregator/Helper), you need to provide the following environment variables for the collection job.
+
+- `DAP_AUTH_BEARER_TOKEN`
+- `DAP_HPKE_CONFIG`
+- `DAP_HPKE_PRIVATE_KEY`
+
+You can also set the following environment variables to override the default settings.
+
+- `DAP_ENV=dev`
+- `DAP_DURATION=600`
+- `DAP_TASK_ID="yL5q2lPLTl1VgHvMEUBB8BEunmdmb7-7QKiRxI0ocTU"`
+- `DAP_LEADER="https://dap-07-1.api.divviup.org"`
+- `DAP_VDAF=sum`
+- `DAP_VDAF_ARGS="--bits 1"`

--- a/scripts/submit-n-collect.sh
+++ b/scripts/submit-n-collect.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+DAP_TIMESTAMP=$((($(date +%s) / DAP_DURATION) * DAP_DURATION))
+
+echo "running the submission job..."
+${DAP_CLIENT}
+
+echo "running the collection job..."
+${DAP_COLLECTOR} --task-id "${DAP_TASK_ID}" --leader "${DAP_LEADER}" --authorization-bearer-token "${DAP_AUTH_BEARER_TOKEN}" \
+  --vdaf "${DAP_VDAF}" ${DAP_VDAF_ARGS} --batch-interval-start "${DAP_TIMESTAMP}" --batch-interval-duration "${DAP_DURATION}" \
+  --hpke-config "${DAP_HPKE_CONFIG}" --hpke-private-key "${DAP_HPKE_PRIVATE_KEY}"


### PR DESCRIPTION
The new script allows us to run both the submission and the collection jobs inside the container with the dead simple default configurations. Credentials can be provided through envvars.